### PR TITLE
DEV-919 [FIX] add lodash as a dependency

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -25,7 +25,8 @@
       "fliplet-helper",
       "fliplet-datasources",
       "fliplet-communicate",
-      "fliplet-csv"
+      "fliplet-csv",
+      "lodash"
     ],
     "assets": [
       "css/build.css",


### PR DESCRIPTION
### Summary

 Adds lodash as an explicit dependency in the widget's widget.json build configuration to ensure it is reliably loaded at runtime.
