### PR TITLE
fix: replace _.assign with Object.assign

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -20,7 +20,7 @@ Fliplet.Widget.instance({
         $(".ai-feature-content").hide();
       }
 
-      AI.fields = _.assign(
+      AI.fields = Object.assign(
         {
           dataSourceId: "",
           dataSourceName: "",


### PR DESCRIPTION
## Summary
- Replace bare `_.assign()` with native `Object.assign()` in `js/build.js` to eliminate lodash dependency

## Context
- **Sentry issue**: [PRODUCTION-WIDGETS-INTERFACE-89E](https://fliplet.sentry.io/issues/PRODUCTION-WIDGETS-INTERFACE-89E) — `ReferenceError: _ is not defined` in `com.fliplet.ai-feature/1.0.0/rendering.js`
- The widget was using `_.assign()` (lodash) without declaring lodash as an explicit build dependency. When lodash isn't loaded (race condition or removed from preload), the widget crashes.
- `Object.assign()` is native JavaScript and functionally identical for this use case.

## Files changed
| File | Change |
|------|--------|
| `js/build.js` | 1 line: `_.assign(...)` → `Object.assign(...)` |

## Test plan
- [ ] Verify AI feature widget loads correctly in Studio preview
- [ ] Verify widget field defaults are applied properly (dataSourceId, css, javascript, layoutHTML, etc.)
- [ ] Check no `_ is not defined` errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)