### PR TITLE
DEV-926 [feat] Exempt AI Feature widget from API rate limits

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -3419,6 +3419,7 @@ Available functions:
             temperature: AIConfig.temperature,
             // max_tokens: CONFIG.MAX_TOKENS,
             // reasoning_effort: "low",
+            _widgetPackage: "com.fliplet.ai-feature",
             response_format: {
               type: "json_schema",
               json_schema: {


### PR DESCRIPTION
## Summary
- Adds `_widgetPackage: "com.fliplet.ai-feature"` to the `createCompletion` request body
- The backend uses this field to skip `aiApiPerMinute`/`aiApiPerDay` enforcement for this widget
- Companion PR: https://github.com/Fliplet/fliplet-api/pull/7629

## JIRA ticket
https://weboo.atlassian.net/browse/DEV-926

🤖 Generated with [Claude Code](https://claude.com/claude-code)