### PR TITLE
Fix corrupted escape sequences in AI-generated code

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1404,12 +1404,6 @@ Available functions:
             let oldString = this.stripDelimiters(instruction.old_string, instruction.target_type);
             let newString = this.stripDelimiters(instruction.new_string, instruction.target_type);
 
-            // Normalize escaped characters (handle JSON-escaped newlines, tabs, etc.)
-            // This ensures oldString and targetCode are in the same format for comparison
-            oldString = this.normalizeEscapedCharacters(oldString);
-            newString = this.normalizeEscapedCharacters(newString);
-            let normalizedTargetCode = this.normalizeEscapedCharacters(targetCode);
-
             // Normalize line endings (CRLF/CR -> LF) and strip trailing whitespace per line.
             // Trailing spaces/tabs at line ends are semantically meaningless in HTML/CSS/JS
             // and are the most common source of AI old_string mismatches — normalizing them
@@ -1420,22 +1414,13 @@ Available functions:
               .replace(/[ \t]+$/gm, "");     // strip trailing spaces/tabs on every line
             oldString = normalizeCode(oldString);
             newString = normalizeCode(newString);
-            normalizedTargetCode = normalizeCode(normalizedTargetCode);
+            let normalizedTargetCode = normalizeCode(targetCode);
 
             // Log if delimiters were found and stripped
             if (oldString !== instruction.old_string || newString !== instruction.new_string) {
               debugLog("🔧 [StringReplacement] Stripped delimiters from AI response:", {
                 oldStringChanged: oldString !== instruction.old_string,
                 newStringChanged: newString !== instruction.new_string,
-                targetType: instruction.target_type
-              });
-            }
-
-            // Log if escaped characters were normalized
-            if (oldString !== instruction.old_string || normalizedTargetCode !== targetCode) {
-              debugLog("🔧 [StringReplacement] Normalized escaped characters:", {
-                oldStringNormalized: oldString !== instruction.old_string,
-                targetCodeNormalized: normalizedTargetCode !== targetCode,
                 targetType: instruction.target_type
               });
             }
@@ -1969,29 +1954,6 @@ Available functions:
             });
           }
 
-          /**
-           * Normalize escaped characters in strings
-           * Converts escaped sequences like \\n, \\t, \\r to actual characters
-           * This handles cases where JSON parsing leaves escaped characters as literal strings
-           * @param {string} str - String that might contain escaped characters
-           * @returns {string} String with escaped characters normalized
-           */
-          normalizeEscapedCharacters(str) {
-            if (!str || typeof str !== 'string') {
-              return str;
-            }
-
-            // Replace common escaped sequences with actual characters
-            // Handle double backslashes first (mark them temporarily) to avoid double-processing
-            return str
-              .replace(/\\\\/g, '\u0001') // Temporary marker for literal double backslash
-              .replace(/\\n/g, '\n')      // Escaped newline -> actual newline
-              .replace(/\\t/g, '\t')      // Escaped tab -> actual tab
-              .replace(/\\r/g, '\r')      // Escaped carriage return -> actual CR
-              .replace(/\\"/g, '"')       // Escaped quote -> actual quote
-              .replace(/\\'/g, "'")       // Escaped apostrophe -> actual apostrophe
-              .replace(/\u0001/g, '\\');  // Restore literal double backslashes
-          }
 
           /**
            * Strip delimiter comments from code strings


### PR DESCRIPTION
## Summary

Removes `normalizeEscapedCharacters` from the string-replacement engine in `js/interface.js`. The function was corrupting valid JS/CSS output from the AI by converting two-character escape sequences (`\n`, `\r`, `\t`, `\"`, `\'`) into their actual control characters — after `JSON.parse` had already produced them correctly.

## The bug

When the AI generates code containing an escape sequence inside a string or regex literal (e.g. `lines.join('\n')`, `/[",\n\r]/`), it correctly double-escapes in JSON (`\n`). `JSON.parse` decodes that to the two-character sequence `\n` — which is exactly what should land in the source file. `normalizeEscapedCharacters` was then running a second unescape pass, turning those two chars into a real newline and breaking the output:

```js
var csv = lines.join('
');                               // ← was: lines.join('\n')

var needsQuotes = /[",

]/.test(v);                       // ← was: /[",\n\r]/
```

## Fix

- Deleted `normalizeEscapedCharacters` (function + three call sites + its debug-log block).
- Matching-related whitespace normalization is unchanged — `normalizeCode` still handles CRLF→LF, CR→LF, and trailing spaces/tabs, which is what actually makes `old_string` matching robust. Existing edge-newline and whitespace-tolerant fallbacks further down the pipeline remain in place.

## Test plan

- [ ] Generate new code containing `\n` / `\r` inside string literals (e.g. `lines.join('\n')`) and confirm it lands in the output verbatim.
- [ ] Generate code with a regex containing escape sequences (e.g. `/[",\n\r]/`) and confirm the regex is syntactically valid in the output file.
- [ ] Verify `old_string` matching still succeeds on existing code that contains literal `\n` / `\r` escape sequences.
- [ ] Verify edit flows for unchanged cases (pure text replacements, HTML-only changes) continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)